### PR TITLE
Skeleton Code for adding Azure Monitor exporter to OC Agent

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,7 @@
+receivers:
+  opencensus:
+    address: "127.0.0.1:55678"
+
+exporters:
+  azureMonitor:
+    instrumentationKey: "111a0d2f-ab53-4b62-a54f-4722f09fd136"

--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,0 @@
-receivers:
-  opencensus:
-    address: "127.0.0.1:55678"
-
-exporters:
-  azureMonitor:
-    instrumentationKey: "111a0d2f-ab53-4b62-a54f-4722f09fd136"

--- a/exporter/azuremonitorexporter/azuremonitor.go
+++ b/exporter/azuremonitorexporter/azuremonitor.go
@@ -1,0 +1,35 @@
+package azuremonitorexporter
+
+import (
+	"github.com/spf13/viper"
+
+	// TODO: once this repository has been transferred to the
+	// official census-ecosystem location, update this import path.
+	"github.com/ChrisCoe/opencensus-go-exporter-azuremonitor/azuremonitor"
+	"github.com/ChrisCoe/opencensus-go-exporter-azuremonitor/azuremonitor/common"
+
+	"github.com/census-instrumentation/opencensus-service/consumer"
+	"github.com/census-instrumentation/opencensus-service/exporter/exporterwrapper"
+)
+
+type azuermonitorconfig struct {
+	InstrumentationKey string `mapstructure:"instrumentationKey"`
+}
+
+// JaegerExportersFromViper unmarshals the viper and returns exporter.TraceExporters targeting
+// Jaeger according to the configuration settings.
+func AzureMonitorExportersFromViper(v *viper.Viper) (tps []consumer.TraceConsumer, mps []consumer.MetricsConsumer, doneFns []func() error, err error) {
+	var cfg struct { // cfg stands for config. I am following the naming convention 
+					 // used for all the exporters in this package
+		AzureMonitor *azuermonitorconfig `mapstructure:"azuremonitor"`
+	}
+	if err := v.Unmarshal(&cfg); err != nil {
+		return nil, nil, nil, err
+	}
+	amc := cfg.AzureMonitor
+	if amc == nil {
+		return nil, nil, nil, nil
+	}
+
+	return
+}

--- a/exporter/azuremonitorexporter/azuremonitor.go
+++ b/exporter/azuremonitorexporter/azuremonitor.go
@@ -16,8 +16,8 @@ type azuermonitorconfig struct {
 	InstrumentationKey string `mapstructure:"instrumentationKey"`
 }
 
-// JaegerExportersFromViper unmarshals the viper and returns exporter.TraceExporters targeting
-// Jaeger according to the configuration settings.
+// AzureMonitorExportersFromViper unmarshals the viper and returns exporter.TraceExporters targeting
+// Azure Monitor according to the configuration settings.
 func AzureMonitorExportersFromViper(v *viper.Viper) (tps []consumer.TraceConsumer, mps []consumer.MetricsConsumer, doneFns []func() error, err error) {
 	var cfg struct { // cfg stands for config. I am following the naming convention 
 					 // used for all the exporters in this package
@@ -31,5 +31,5 @@ func AzureMonitorExportersFromViper(v *viper.Viper) (tps []consumer.TraceConsume
 		return nil, nil, nil, nil
 	}
 
-	return
+	return nil //TODO: Create exporter from cfg for next PR
 }

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	contrib.go.opencensus.io/exporter/stackdriver v0.12.3-0.20190626200219-09504ed717c7 // TODO: pin a released version
 	contrib.go.opencensus.io/exporter/zipkin v0.1.1
 	contrib.go.opencensus.io/resource v0.1.1
+	github.com/ChrisCoe/opencensus-go-exporter-azuremonitor v0.0.0-20190711172825-09f39f7ce008
 	github.com/DataDog/datadog-go v2.2.0+incompatible // indirect
 	github.com/DataDog/opencensus-go-exporter-datadog v0.0.0-20181026070331-e7c4bd17b329
 	github.com/VividCortex/gohistogram v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,15 @@ github.com/Azure/go-autorest v10.8.1+incompatible h1:u0jVQf+a6k6x8A+sT60l6EY9XZu
 github.com/Azure/go-autorest v10.8.1+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/ChrisCoe/opencensus-go v0.22.0 h1:HSw2iPPZTZMRcwo+oakGDBYFf7C4OeRxjRqArn+dPY0=
+github.com/ChrisCoe/opencensus-go-exporter-azuremonitor v0.0.0-20190711010340-edbc0f606ea3 h1:hKP6UZgYa7LY8xiTURg51ifkQ/+efuNuCGhsQC5I9cI=
+github.com/ChrisCoe/opencensus-go-exporter-azuremonitor v0.0.0-20190711010340-edbc0f606ea3/go.mod h1:QxpXE0qPdcRvfaV4czo7OpdmYKVxagRuYboxAJoLuyI=
+github.com/ChrisCoe/opencensus-go-exporter-azuremonitor v0.0.0-20190711061722-23dcf9852277 h1:Ck/7lStEwOfaVTtnkWU0XY6QNzaO+n6/WMkV9c7mAfU=
+github.com/ChrisCoe/opencensus-go-exporter-azuremonitor v0.0.0-20190711061722-23dcf9852277/go.mod h1:QxpXE0qPdcRvfaV4czo7OpdmYKVxagRuYboxAJoLuyI=
+github.com/ChrisCoe/opencensus-go-exporter-azuremonitor v0.0.0-20190711134204-144fed1d6221 h1:Sp2JpgNpim9xKlzClBldcApFntMPKEXsOD9Wi3LIQ8Y=
+github.com/ChrisCoe/opencensus-go-exporter-azuremonitor v0.0.0-20190711134204-144fed1d6221/go.mod h1:QxpXE0qPdcRvfaV4czo7OpdmYKVxagRuYboxAJoLuyI=
+github.com/ChrisCoe/opencensus-go-exporter-azuremonitor v0.0.0-20190711172825-09f39f7ce008 h1:t3WdkSso2Az2xCSaQob/xUfTHcu/CF/2m7wdOgFk49Y=
+github.com/ChrisCoe/opencensus-go-exporter-azuremonitor v0.0.0-20190711172825-09f39f7ce008/go.mod h1:QxpXE0qPdcRvfaV4czo7OpdmYKVxagRuYboxAJoLuyI=
 github.com/DataDog/datadog-go v2.2.0+incompatible h1:V5BKkxACZLjzHjSgBbr2gvLA2Ae49yhc6CSY7MLy5k4=
 github.com/DataDog/datadog-go v2.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/opencensus-go-exporter-datadog v0.0.0-20181026070331-e7c4bd17b329 h1:WOxkY7ClXANNyQQuq4rxQrM/nQnjXCpvqY0ipYxB9cQ=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/census-instrumentation/opencensus-service/consumer"
 	"github.com/census-instrumentation/opencensus-service/exporter/awsexporter"
+	"github.com/census-instrumentation/opencensus-service/exporter/azuremonitorexporter"
 	"github.com/census-instrumentation/opencensus-service/exporter/datadogexporter"
 	"github.com/census-instrumentation/opencensus-service/exporter/honeycombexporter"
 	"github.com/census-instrumentation/opencensus-service/exporter/jaegerexporter"
@@ -468,6 +469,7 @@ func ExportersFromViperConfig(logger *zap.Logger, v *viper.Viper) ([]consumer.Tr
 		{name: "prometheus", fn: prometheusexporter.PrometheusExportersFromViper},
 		{name: "aws-xray", fn: awsexporter.AWSXRayTraceExportersFromViper},
 		{name: "honeycomb", fn: honeycombexporter.HoneycombTraceExportersFromViper},
+		{name: "azuremonitor", fn: azuremonitorexporter.AzureMonitorExportersFromViper},
 	}
 
 	var traceExporters []consumer.TraceConsumer


### PR DESCRIPTION
I unmarshel the viper following the format of all the other exporters in this package. The mod and sum files are automatically generated with my imports.

@reyang @lzchen