### PR TITLE
Create exporter wrapper from Azure Monitor exporter

### DIFF
--- a/exporter/azuremonitorexporter/azuremonitor.go
+++ b/exporter/azuremonitorexporter/azuremonitor.go
@@ -18,7 +18,7 @@ type azuermonitorconfig struct {
 
 // AzureMonitorExportersFromViper unmarshals the viper and returns exporter.TraceExporters targeting
 // Azure Monitor according to the configuration settings.
-func AzureMonitorExportersFromViper(v *viper.Viper) (tps []consumer.TraceConsumer, mps []consumer.MetricsConsumer, doneFns []func() error, err error) {
+func AzureMonitorExportersFromViper(v *viper.Viper) (traceExporters []consumer.TraceConsumer, metricExporters []consumer.MetricsConsumer, doneFns []func() error, err error) {
 	var cfg struct { // cfg stands for config. I am following the naming convention 
 					 // used for all the exporters in this package
 		AzureMonitor *azuermonitorconfig `mapstructure:"azuremonitor"`
@@ -26,12 +26,12 @@ func AzureMonitorExportersFromViper(v *viper.Viper) (tps []consumer.TraceConsume
 	if err := v.Unmarshal(&cfg); err != nil {
 		return nil, nil, nil, err
 	}
-	amc := cfg.AzureMonitor
-	if amc == nil {
+	azureMonitorConfig := cfg.AzureMonitor
+	if azureMonitorConfig == nil {
 		return nil, nil, nil, nil
 	}
-	azureexporter, err := azuremonitor.NewAzureTraceExporter(common.Options{
-		InstrumentationKey: amc.InstrumentationKey, // add InstrumentationKey
+	azureExporter, err := azuremonitor.NewAzureTraceExporter(common.Options{
+		InstrumentationKey: azureMonitorConfig.InstrumentationKey, // add InstrumentationKey
 	})
 
 	if err != nil {
@@ -42,11 +42,11 @@ func AzureMonitorExportersFromViper(v *viper.Viper) (tps []consumer.TraceConsume
 		return nil
 	})
 
-	amte, err := exporterwrapper.NewExporterWrapper("azuremonitor", "ocservice.exporter.AzureMonitor.ConsumeTraceData", azureexporter)
+	azureMonitorTraceExporter, err := exporterwrapper.NewExporterWrapper("azuremonitor", "ocservice.exporter.AzureMonitor.ConsumeTraceData", azureExporter)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
-	tps = append(tps, amte)
+	traceExporters = append(traceExporters, azureMonitorTraceExporter)
 	return
 }

--- a/exporter/azuremonitorexporter/azuremonitor.go
+++ b/exporter/azuremonitorexporter/azuremonitor.go
@@ -30,6 +30,23 @@ func AzureMonitorExportersFromViper(v *viper.Viper) (tps []consumer.TraceConsume
 	if amc == nil {
 		return nil, nil, nil, nil
 	}
+	azureexporter, err := azuremonitor.NewAzureTraceExporter(common.Options{
+		InstrumentationKey: amc.InstrumentationKey, // add InstrumentationKey
+	})
 
-	return nil //TODO: Create exporter from cfg for next PR
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	doneFns = append(doneFns, func() error {
+		return nil
+	})
+
+	amte, err := exporterwrapper.NewExporterWrapper("azuremonitor", "ocservice.exporter.AzureMonitor.ConsumeTraceData", azureexporter)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	tps = append(tps, amte)
+	return
 }


### PR DESCRIPTION
I create an Azure monitor exporter using the iKey from the config structure. I then add this to an exporter wrapper so that the OC agent can process this. 

@lzchen @reyang