### PR TITLE
Add config yaml file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ cmd/occollector/occollector_linux
 # Coverage
 coverage.txt
 coverage.html
+
+# Source Code
+config.yaml


### PR DESCRIPTION
Most developers on this repo probably have their own config file. This doesn't need to be shared so I'm adding it to the current .gitignore file.

@reyang @lzchen 